### PR TITLE
Initial 64bit malloc support when BIT64 is enabled

### DIFF
--- a/doc/Glossary-Concise.txt
+++ b/doc/Glossary-Concise.txt
@@ -1105,25 +1105,25 @@ Compare n1 and n2. Return `TRUE` if n1 is less than n2, or `FALSE` otherwise.
 lteq?                     D: nn-f  A: -  F: -
 Compare n1 and n2. Return `TRUE` if n1 is less than or equal to n2, or `FALSE` otherwise.
 
-mem:alloc                 D: n-nn  A: -  F: -
+mem:alloc                 D: n-n  A: -  F: -
 Use malloc to allocate memory. Returns a double cell pointer to this memory.
 
-mem:cell+                 D: nnn-n  A: -  F: -
+mem:cell+                 D: nn-n  A: -  F: -
 Return address of next cell. Uses a double cell pointer on the stack.
 
 mem:fetch                 D: nn-n  A: -  F: -
 Fetch value from malloc'd memory region. Address is a double cell value.
 
-mem:fetch-double          D: nn-n  A: -  F: -
+mem:fetch-double          D: nn-nn  A: -  F: -
 Fetch a double cell value from a malloc memory region.
 
-mem:free                  D: nn-  A: -  F: -
+mem:free                  D: n-  A: -  F: -
 Fre a malloc'd region of memory. Pass a double cell pointer to the memory to free.
 
-mem:resize                D: mmn-  A: -  F: -
+mem:resize                D: mn-  A: -  F: -
 Resize a malloc'd memory area.
 
-mem:store                 D: xnn-  A: -  F: -
+mem:store                 D: xn-  A: -  F: -
 Store a value into a malloc'd memory region. Uses a double cell pointer for the address.
 
 mod                       D: nm-o  A: -  F: -

--- a/interface/malloc.retro
+++ b/interface/malloc.retro
@@ -13,16 +13,16 @@
 
 ---reveal---
 
-  :mem:alloc  (n--aa) ALLOC  mem:invoke ;
-  :mem:store  (an--)  STORE  mem:invoke ;
-  :mem:fetch  (a--n)  FETCH  mem:invoke ;
-  :mem:free   (aa--)  FREE   mem:invoke ;
-  :mem:resize (aan--) RESIZE mem:invoke ;
+  :mem:alloc  (n--a) ALLOC  mem:invoke ;
+  :mem:store  (an--) STORE  mem:invoke ;
+  :mem:fetch  (a--n) FETCH  mem:invoke ;
+  :mem:free   (a--)  FREE   mem:invoke ;
+  :mem:resize (an--) RESIZE mem:invoke ;
 }}
 
-:mem:cell+ (nnn-n) #4 * + ;
+:mem:cell+ (nn-n) #8 * + ;
 :mem:fetch-double (n-nn)
-  dup-pair #1 mem:cell+ fetch push mem:fetch pop ;
-:mem:store-double (aann-nn)
+  dup #1 mem:cell+ fetch push mem:fetch pop ;
+:mem:store-double (ann-nn)
   push push dup-pair #1 mem:cell+ pop mem:store pop mem:store ;
 ~~~


### PR DESCRIPTION
@crcx I realize you don't use GH or Git for your usual workflow, so we can close this when it is merged.

I look forward to your feedback.

What is your opinion on backward compatibility? This PR removes `mem:` support from 32-bit builds. It feels strange to have a set of words with different function signatures depending on the bitness of the build. Eg: 32 bit `mem:` words return double but 64 bit `mem:` words return cells.